### PR TITLE
Refactor TextEditorHandler to use TemplateRendererBridgeInterface

### DIFF
--- a/Application/Controller/TextEditorHandler.php
+++ b/Application/Controller/TextEditorHandler.php
@@ -24,6 +24,8 @@
 namespace OxidEsales\WysiwygModule\Application\Controller;
 
 use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\EshopCommunity\Internal\Container\ContainerFactory;
+use OxidEsales\EshopCommunity\Internal\Framework\Templating\TemplateRendererBridgeInterface;
 
 /**
  * Class TextEditorHandler
@@ -56,24 +58,22 @@ class TextEditorHandler extends TextEditorHandler_parent
         $oConfig = $this->getConfig();
         $oLang = Registry::getLang();
 
-        $oUtilsView = Registry::get('oxUtilsView');
-        $oSmarty = $oUtilsView->getSmarty(true);
-
-        $oSmarty->assign('oView', $this->getView());
-        $oSmarty->assign('oViewConf', $this->getViewConfig());
-
-        $oSmarty->assign('sEditorField', $fieldName);
-        $oSmarty->assign('sEditorValue', $objectValue);
-        $oSmarty->assign('iEditorHeight', $height);
-        $oSmarty->assign('iEditorWidth', $width);
-        $oSmarty->assign('blTextEditorDisabled', $this->isTextEditorDisabled());
+        $container = ContainerFactory::getInstance()->getContainer();
+        $bridge = $container->get(TemplateRendererBridgeInterface::class);
+        $renderer = $bridge->getTemplateRenderer();
 
         $iDynInterfaceLanguage = $oConfig->getConfigParam('iDynInterfaceLanguage');
         $sLangAbbr = $oLang->getLanguageAbbr((isset($iDynInterfaceLanguage) ? $iDynInterfaceLanguage : $oLang->getTplLanguage()));
 
-        $oSmarty->assign('langabbr', $sLangAbbr);
-
-        return $oSmarty->fetch('ddoewysiwyg.tpl');
+        return $renderer->renderTemplate('ddoewysiwyg.tpl', [
+            'oView' => $this->getView(),
+            'oViewConf' => $this->getViewConfig(),
+            'sEditorField' => $fieldName,
+            'iEditorHeight' => $height,
+            'iEditorWidth' => $width,
+            'blTextEditorDisabled' => $this->isTextEditorDisabled(),
+            'langabbr' => $sLangAbbr,
+        ]);
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.4.3] - unreleased
 
+### Added
+- TemplateRendererBridgeInterface so it can use OXID smarty legacy
+
 ### Changed
 - License updated - now using OXID Module and Component License
 


### PR DESCRIPTION
Changes:

- Replaced the direct Smarty calls with calls to the TemplateRenderer::renderTemplate method.
- Removed unnecessary Smarty assignments. This is now handled in the TemplateRendered